### PR TITLE
Explicitly set menu icon padding

### DIFF
--- a/assets/stylesheets/time_tracker.css
+++ b/assets/stylesheets/time_tracker.css
@@ -3,6 +3,7 @@
 
 #time-tracker-menu { margin-right: 8px; }
 #time-tracker-menu a { margin-right: 0px; }
+#time-tracker-menu .icon { padding-left: 20px; }
 
 #time-tracker-admin td.start-date,
 #time-tracker-admin td.spent-time,


### PR DESCRIPTION
When using this plugin with the basecamp theme, the icon was overlapping the text because that theme changed the padding for the menu items.  The line I added to the css just sets the padding expected so the plugin doesn't rely on the theme for that value.
