### PR TITLE
Use preceding slash to anchor controller name in all code generating links to TimeTracker controller

### DIFF
--- a/app/views/time_trackers/_embed_menu.rhtml
+++ b/app/views/time_trackers/_embed_menu.rhtml
@@ -3,33 +3,33 @@
     <% if time_tracker.paused %>
         <%# A time tracker is in pause, display the tracked issue, the time spent and the resume/stop actions %>
         <%= link_to '#' + time_tracker.issue_id.to_s,
-            { :controller => 'issues', :action => 'show', :id => time_tracker.issue_id },
+            { :controller => '/issues', :action => 'show', :id => time_tracker.issue_id },
             { :class => 'icon icon-pause' }
         %>
          / <%= time_tracker.time_spent_to_s %> /
         <%= link_to_remote '',
-            :url => { :controller => 'time_trackers', :action => 'resume' },
+            :url => { :controller => '/time_trackers', :action => 'resume' },
             :html => { :class => 'icon-action icon-start-action', :title => l(:resume_time_tracker) },
             :update => 'time-tracker-menu'
         %>
         <%= link_to '',
-            { :controller => 'time_trackers', :action => 'stop' },
+            { :controller => '/time_trackers', :action => 'stop' },
             { :class => 'icon-action icon-stop-action', :title => l(:stop_time_tracker) }
          %>
     <% else %>
         <%# A time tracker is running, display the tracked issue, the time spent and the suspend/stop actions %>
         <%= link_to '#' + time_tracker.issue_id.to_s,
-            { :controller => 'issues', :action => 'show', :id => time_tracker.issue_id },
+            { :controller => '/issues', :action => 'show', :id => time_tracker.issue_id },
             { :class => 'icon icon-clock' }
         %>
          / <%= time_tracker.time_spent_to_s %> /
         <%= link_to_remote '',
-            :url => { :controller => 'time_trackers', :action => 'suspend' },
+            :url => { :controller => '/time_trackers', :action => 'suspend' },
             :html => { :class => 'icon-action icon-pause-action', :title => l(:suspend_time_tracker) },
             :update => 'time-tracker-menu'
         %>
         <%= link_to '',
-            { :controller => 'time_trackers', :action => 'stop' },
+            { :controller => '/time_trackers', :action => 'stop' },
             { :class => 'icon-action icon-stop-action', :title => l(:stop_time_tracker) }
         %>
     <% end %>
@@ -37,7 +37,7 @@
     <%# No time tracker is running, but the user look at an issue and he has the rights to track time on it %>
     <%# Display the start time tracker action on this issue %>
     <%= link_to_remote l(:start_time_tracker) + ' #' + @issue.id.to_s + '&nbsp;',
-        :url => { :controller => 'time_trackers', :action => 'start', :issue_id => @issue.id },
+        :url => { :controller => '/time_trackers', :action => 'start', :issue_id => @issue.id },
         :html => { :class => 'icon icon-start' },
         :update => 'time-tracker-menu'
     %>
@@ -50,7 +50,7 @@
 <% if User.current.allowed_to?(:log_time, nil, :global => true) or User.current.allowed_to?(:view_others_time_trackers, nil, :global => true) %>
     <span>
         <%= link_to '',
-            { :controller => 'time_trackers', :action => 'index' },
+            { :controller => '/time_trackers', :action => 'index' },
             { :class => 'icon-action icon-list-action', :title => l(:list_time_trackers) }
         %>
     </span>

--- a/app/views/time_trackers/_status_transition_list.rhtml
+++ b/app/views/time_trackers/_status_transition_list.rhtml
@@ -41,7 +41,7 @@
                             <% if edit_allowed %>
                                 <td class="buttons">
                                     <%= link_to_remote l(:time_tracker_label_delete),
-                                        :url => { :controller => 'time_trackers', :action => 'delete_status_transition', :transitions => transitions, :from_id => from },
+                                        :url => { :controller => '/time_trackers', :action => 'delete_status_transition', :transitions => transitions, :from_id => from },
                                         :html => { :class => 'icon icon-del' },
                                         :complete => "$('status-transition-list').replace(request.responseText);"
                                     %>
@@ -65,7 +65,7 @@
             <%= label_tag 'new-transition-to', l(:time_tracker_settings_new_transition_to) %>
             <%= select_tag 'new-transition-to', new_transition_to_options %>
             <%= link_to_remote l(:time_tracker_settings_new_transition_add),
-                :url => { :controller => 'time_trackers', :action => 'add_status_transition', :transitions => transitions },
+                :url => { :controller => '/time_trackers', :action => 'add_status_transition', :transitions => transitions },
                 :with => "'from_id=' + $('new-transition-from').value + '&to_id=' + $('new-transition-to').value",
                 :html => { :class => 'icon icon-add' },
                 :complete => "$('status-transition-list').replace(request.responseText);"

--- a/app/views/time_trackers/_update_context.rhtml
+++ b/app/views/time_trackers/_update_context.rhtml
@@ -4,7 +4,7 @@
         <%# A time tracker is paused, display the resume action %>
         <li>
         <%= link_to_remote l(:resume_time_tracker).capitalize + ' #' + time_tracker.issue_id.to_s,
-            :url => { :controller => 'time_trackers', :action => 'resume' },
+            :url => { :controller => '/time_trackers', :action => 'resume' },
             :html => { :class => 'icon icon-start' },
             :update => 'time-tracker-menu'
         %>
@@ -13,16 +13,16 @@
         <%# A time tracker is not paused, display the suspend action %>
         <li>
         <%= link_to_remote l(:suspend_time_tracker).capitalize + ' #' + time_tracker.issue_id.to_s,
-            :url => { :controller => 'time_trackers', :action => 'suspend' },
+            :url => { :controller => '/time_trackers', :action => 'suspend' },
             :html => { :class => 'icon icon-pause' },
             :update => 'time-tracker-menu'
         %>
         </li>
     <% end %>
- 
+
     <%# A time tracker exists, display the stop action %>
     <li>
-        <%= link_to l(:stop_time_tracker).capitalize + ' #' + time_tracker.issue_id.to_s, { :controller => 'time_trackers', :action => 'stop' },
+        <%= link_to l(:stop_time_tracker).capitalize + ' #' + time_tracker.issue_id.to_s, { :controller => '/time_trackers', :action => 'stop' },
             { :class => 'icon icon-stop' } %>
     </li>
 <% elsif !@project.nil? and !@issue.nil? and User.current.allowed_to?(:log_time, @project) %>
@@ -30,7 +30,7 @@
     <%# Display the start time tracker action %>
     <li>
         <%= link_to_remote l(:start_time_tracker).capitalize + ' #' + @issue.id.to_s,
-            :url => { :controller => 'time_trackers', :action => 'start', :issue_id => @issue.id },
+            :url => { :controller => '/time_trackers', :action => 'start', :issue_id => @issue.id },
             :html => { :class => 'icon icon-start' },
             :update => 'time-tracker-menu'
         %>

--- a/app/views/time_trackers/_update_menu.rhtml
+++ b/app/views/time_trackers/_update_menu.rhtml
@@ -18,7 +18,7 @@ the time tracker menu item using an AJAX request to retrieve the data
 -->
 <%= javascript_tag "function updateTimeTrackerMenu() {
     #{remote_function(
-        :url => { :controller => 'time_trackers', :action => 'render_menu', :project_id => (@project.nil? ? nil : @project.id), :issue_id => (@issue.nil? ? nil : @issue.id) },
+        :url => { :controller => '/time_trackers', :action => 'render_menu', :project_id => (@project.nil? ? nil : @project.id), :issue_id => (@issue.nil? ? nil : @issue.id) },
         :before => "Ajax.activeRequestCount--",
         :complete => "updateElementIfChanged('time-tracker-menu', request.responseText);")
     };}"

--- a/app/views/time_trackers/index.rhtml
+++ b/app/views/time_trackers/index.rhtml
@@ -32,7 +32,7 @@
                                 <td class="spent-time"><%= time_tracker.time_spent_to_s %></td>
                                 <td class="buttons">
                                     <%= link_to_remote l(:time_tracker_label_delete),
-                                        :url => { :controller => 'time_trackers', :action => 'delete', :id => time_tracker.id },
+                                        :url => { :controller => '/time_trackers', :action => 'delete', :id => time_tracker.id },
                                         :html => { :class => 'icon icon-del' },
                                         :complete => "$('#{'user-timetracker' + time_tracker.id.to_s}').update('<td colspan=\"0\" class=\"msg\">' + request.responseText + '</td>');"
                                     %>
@@ -81,7 +81,7 @@
                                 <td class="buttons">
                                     <% if User.current.allowed_to?(:delete_others_time_trackers, nil, :global => true) %>
                                         <%= link_to_remote l(:time_tracker_label_delete),
-                                            :url => { :controller => 'time_trackers', :action => 'delete', :id => time_tracker.id },
+                                            :url => { :controller => '/time_trackers', :action => 'delete', :id => time_tracker.id },
                                             :html => { :class => 'icon icon-del' },
                                             :complete => "$('#{'all-timetracker' + time_tracker.id.to_s}').update('<td colspan=\"0\" class=\"msg\">' + request.responseText + '</td>');"
                                         %>


### PR DESCRIPTION
I copy description from the commit because I think it describes the problem well:

If somebody uses namespaced controllers in their code rails will to
generate namespaced links. Let's say you have controller with full name
_CompanyName::OfficesController_ and have views rendered in it. All URLs
generated for this plugin, for example from this code:

```
{ :controller => 'issues', :action => 'show', :id => time_tracker.issue_id }
```

will have prefix _/company_name/_, in this case:

```
/company_name/issues/4242
```

which is wrong. To preven it you need to prefix all controller names with slashes
or use named routes.

You can read more about namespaces and routing here:

```
http://guides.rubyonrails.org/v2.3.11/routing.html#controller-namespaces-and-routing
```
